### PR TITLE
Add support for local registry cache

### DIFF
--- a/cgyle/proxy.py
+++ b/cgyle/proxy.py
@@ -16,9 +16,15 @@
 # along with cgyle.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import yaml
+import time
+from pathlib import Path
+from textwrap import dedent
+from tempfile import NamedTemporaryFile
 import logging
 import subprocess
 from typing import Optional
+from cgyle.catalog import Catalog
 from cgyle.exceptions import CgyleCommandError
 
 
@@ -27,17 +33,18 @@ class DistributionProxy:
     Access methods for the distribution registry
     configured as proxy
     """
-    def __init__(self, server: str, container: str) -> None:
+    def __init__(self, server: str, container: str = '') -> None:
         self.server = server
         self.container = container
         self.skopeo: Optional[subprocess.Popen[bytes]] = None
+        self.registry_name = ''
         self.pid = 0
 
     def __enter__(self):
         return self
 
     def update_cache(
-        self, tag: str = 'latest', tls_verify: bool = True
+        self, tag: str = '', tls_verify: bool = True
     ) -> None:
         """
         Trigger a cache update of the container
@@ -45,11 +52,12 @@ class DistributionProxy:
         server = self.server
         server = server.replace('http://', '')
         server = server.replace('https://', '')
+        tagname = f':{tag}' if tag else ''
         call_args = [
             'skopeo', 'copy',
             f'--src-tls-verify={format(tls_verify).lower()}',
-            f'docker://{server}/{self.container}:{tag}',
-            f'oci-archive:/dev/null:{tag}'
+            f'docker://{server}/{self.container}{tagname}',
+            f'oci-archive:/dev/null{tagname}'
         ]
         try:
             self.skopeo = subprocess.Popen(
@@ -79,7 +87,97 @@ class DistributionProxy:
     def get_pid(self) -> str:
         return format(self.pid)
 
+    def create_local_distribution_instance(
+        self, data_dir: str, remote: str, port: int = 5000
+    ) -> str:
+        self.registry_config = NamedTemporaryFile(prefix='cgyle_local_dist')
+        with open(self.registry_config.name, 'w') as config:
+            yaml.dump(self._get_distribution_config(remote, port), config)
+        logging.info(
+            f'Find local registry data at: {os.path.abspath(data_dir)}'
+        )
+        Path(data_dir).mkdir(parents=True, exist_ok=True)
+        self.registry_name = f'{os.path.basename(self.registry_config.name)}'
+        podman_create_args = [
+            'podman', 'run', '--detach', '--name', self.registry_name,
+            '-p', f'{port}:{port}',
+            '-v', f'{os.path.abspath(data_dir)}/:/var/lib/registry/',
+            '-v', f'{self.registry_config.name}:/etc/docker/registry/config.yml',
+            'docker.io/library/registry:latest'
+        ]
+        try:
+            podman_create = subprocess.Popen(
+                podman_create_args,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE
+            )
+            output, error = podman_create.communicate()
+            if error:
+                raise CgyleCommandError(
+                    f'Failed to create distribution instance: {error!r}'
+                )
+
+            registry_url = f'http://localhost:{port}'
+            retry = 0
+            max_retry = 10
+            catalog_issue = ''
+            catalog = Catalog()
+            while retry < max_retry:
+                try:
+                    catalog.get_catalog(registry_url)
+                    break
+                except Exception as issue:
+                    catalog_issue = format(issue)
+                    time.sleep(1)
+                    retry += 1
+            if retry >= max_retry:
+                raise CgyleCommandError(
+                    f'Distribution instance not reachable: {catalog_issue}'
+                )
+            return registry_url
+        except Exception as issue:
+            raise CgyleCommandError(
+                f'Failed to create distribution instance: {issue!r}'
+            )
+
+    def _get_distribution_config(self, remote: str, port: int) -> dict:
+        config_string = dedent('''
+            version: 0.1
+            log:
+              fields:
+                service: registry
+            storage:
+              cache:
+                blobdescriptor: inmemory
+              filesystem:
+                rootdirectory: /var/lib/registry
+              delete:
+                enabled: true
+            http:
+              addr: :SOME
+              headers:
+                X-Content-Type-Options: [nosniff]
+            health:
+              storagedriver:
+                enabled: true
+                interval: 10s
+                threshold: 3
+            proxy:
+              remoteurl: SOME
+              ttl: 168h
+        ''').strip()
+        config = yaml.safe_load(config_string)
+        config['http']['addr'] = f':{port}'
+        config['proxy']['remoteurl'] = remote
+        return config
+
     def __exit__(self, exc_type, exc_value, traceback):
+        if self.registry_name:
+            subprocess.Popen(
+                ['podman', 'rm', '--force', self.registry_name],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE
+            ).communicate()
         if exc_type == KeyboardInterrupt:
             if self.pid > 0:
                 os.kill(self.pid, 15)

--- a/package/python-cgyle-spec-template
+++ b/package/python-cgyle-spec-template
@@ -64,6 +64,7 @@ BuildRequires:  python%{python3_pkgversion}-wheel
 BuildRequires:  python%{python3_pkgversion}-docopt >= 0.6.2
 BuildRequires:  python%{python3_pkgversion}-requests
 BuildRequires:  python%{python3_pkgversion}-setuptools
+BuildRequires:  python%{python3_pkgversion}-PyYAML
 
 %description
 Tooling for the pubcloud team. Allows to pre-populate
@@ -82,6 +83,7 @@ Requires:       python%{python3_pkgversion} >= 3.9
 Requires:       python%{python3_pkgversion}-docopt
 Requires:       python%{python3_pkgversion}-requests
 Requires:       python%{python3_pkgversion}-setuptools
+Requires:       python%{python3_pkgversion}-PyYAML
 Requires:       skopeo
 Requires:       podman
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ classifiers = [
 python = "^3.9"
 docopt-ng = ">=0.9.0"
 requests = ">=2.25.0"
+PyYAML = ">=5.4.0"
 setuptools = ">=50"
 psutil = "*"
 

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -2,6 +2,6 @@ import sys
 
 # default commandline used for any test, overwrite when needed
 sys.argv = [
-    sys.argv[0], '--updatecache', 'localhost:5000', '--from', 'registry.opensuse.org'
+    sys.argv[0], '--updatecache', 'local://distribution:some', '--from', 'registry.opensuse.org'
 ]
 argv_cgyle_tests = sys.argv


### PR DESCRIPTION
Using the option setting --updatecache local://distribution:DIR allows to create a local cache in the format of the 'distribution' registry to allow preserving the data tree of this server