### PR TITLE
Add support for skipping policy sections

### DIFF
--- a/cgyle/catalog.py
+++ b/cgyle/catalog.py
@@ -116,7 +116,9 @@ class Catalog:
                     )
         return sorted(result)
 
-    def translate_policy(self, policy_file: str) -> List[str]:
+    def translate_policy(
+        self, policy_file: str, skip_sections: List[str] = []
+    ) -> List[str]:
         result: List[str] = []
         glob_regexp_map = {
             '*': '[^/]+',
@@ -125,8 +127,13 @@ class Catalog:
         with open(policy_file) as policy:
             policy_dict = yaml.safe_load(policy)
             for category in policy_dict:
-                for pattern in policy_dict.get(category):
-                    pattern = pattern.replace('**', glob_regexp_map.get('**'))
-                    pattern = pattern.replace('*', glob_regexp_map.get('*'))
-                    result.append(f'^{pattern}$')
+                if category not in skip_sections:
+                    for pattern in policy_dict.get(category):
+                        pattern = pattern.replace(
+                            '**', glob_regexp_map.get('**')
+                        )
+                        pattern = pattern.replace(
+                            '*', glob_regexp_map.get('*')
+                        )
+                        result.append(f'^{pattern}$')
         return result

--- a/cgyle/cli.py
+++ b/cgyle/cli.py
@@ -20,7 +20,7 @@ usage: cgyle -h | --help
        cgyle --updatecache=<proxy> --from=<registry>
            [--apply]
            [--filter=<expression>]
-           [--filter-policy=<policyfile>]
+           [--filter-policy=<policyfile>|(--filter-policy=<policyfile> --skip-policy-section=<name>...)]
            [--registry-creds=<user:pwd>]
            [--store-oci=<dir>]
            [--tls-verify-proxy=<BOOL>]
@@ -37,6 +37,10 @@ options:
     --filter-policy=<policyfile>
         Apply rules provided in the policyfile on the
         list of containers received from the registry
+
+    --skip-policy-section=<name>...
+        Skip the provided section name from the policyfile.
+        This option can be specified multiple times.
 
     --from=<registry>
         Registry location to read the catalog of containers
@@ -104,6 +108,8 @@ class Cli:
         self.cache = self.arguments['--updatecache']
         self.pattern = self.arguments['--filter']
         self.policy = self.arguments['--filter-policy']
+        self.policy_skip_sections: List[str] = \
+            self.arguments['--skip-policy-section']
         self.from_registry = self.arguments['--from']
         self.store_oci = self.arguments['--store-oci'] or ''
 
@@ -194,7 +200,9 @@ class Cli:
 
         if self.policy:
             result = catalog.apply_filter(
-                result, catalog.translate_policy(self.policy)
+                result, catalog.translate_policy(
+                    self.policy, self.policy_skip_sections
+                )
             )
 
         if self.pattern:

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -42,7 +42,7 @@ class TestCli:
             call(['some-container'], ['.*'])
         ]
         catalog.translate_policy.assert_called_once_with(
-            '../data/policy'
+            '../data/policy', []
         )
 
     @patch.object(Cli, '_get_catalog')


### PR DESCRIPTION
Add new option --skip-policy-section which can be specified multiple times and only in combination with --policy-file. The provided section names are excluded from the policy file handling if present