### PR TITLE
Fix policy glob match

### DIFF
--- a/cgyle/catalog.py
+++ b/cgyle/catalog.py
@@ -120,20 +120,12 @@ class Catalog:
         self, policy_file: str, skip_sections: List[str] = []
     ) -> List[str]:
         result: List[str] = []
-        glob_regexp_map = {
-            '*': '[^/]+',
-            '**': '.+'
-        }
         with open(policy_file) as policy:
             policy_dict = yaml.safe_load(policy)
             for category in policy_dict:
                 if category not in skip_sections:
                     for pattern in policy_dict.get(category):
-                        pattern = pattern.replace(
-                            '**', glob_regexp_map.get('**')
-                        )
-                        pattern = pattern.replace(
-                            '*', glob_regexp_map.get('*')
-                        )
+                        pattern = re.sub('(?<!\*)\*(?!\*)', '[^/]*', pattern)
+                        pattern = re.sub('\*\*', '.*', pattern)
                         result.append(f'^{pattern}$')
         return result

--- a/test/data/policy.test
+++ b/test/data/policy.test
@@ -1,0 +1,12 @@
+---
+test:
+  - "foo/*"
+  - "sles/**"
+  - "bar*"
+  - "sles"
+  - "foo/*"
+  - "sles/more**"
+  - "sles/more*/sles"
+  - "sles/*super/sles"
+  - "sles**things"
+  - "suse/manager/*-x86_64"

--- a/test/unit/catalog_test.py
+++ b/test/unit/catalog_test.py
@@ -76,10 +76,40 @@ class TestCatalog:
             ['suse/foo/bar', 'bcl/xxx'], [r'.*bcl.*']
         ) == ['bcl/xxx']
 
+    def test_apply_policy(self):
+        assert self.catalog.apply_filter(
+            [
+                'foo/bar/foobar',
+                'foo/bar',
+                'sles/more/things',
+                'sles/moresuper/sles',
+                'extra_repo',
+                'bar',
+                'bat',
+                'bar/foo',
+                'sles',
+                'suse/manager/proxy-aarch64',
+                'suse/manager/server-aarch64',
+                'suse/manager/proxy-ppc64le',
+                'suse/manager/server-ppc64le',
+                'suse/manager/proxy-x86_64',
+                'suse/manager/server-x86_64'
+            ],
+            self.catalog.translate_policy('../data/policy.test')
+        ) == [
+            'bar',
+            'foo/bar',
+            'sles',
+            'sles/more/things',
+            'sles/moresuper/sles',
+            'suse/manager/proxy-x86_64',
+            'suse/manager/server-x86_64'
+        ]
+
     def test_translate_policy(self):
         assert self.catalog.translate_policy('../data/policy') == [
-            '^[^/]+$',
-            '^bci/.+$',
-            '^suse/[^/]+$',
-            '^foo/[^/]+/bar/.+$'
+            '^[^/]*$',
+            '^bci/.*$',
+            '^suse/[^/]*$',
+            '^foo/[^/]*/bar/.*$'
         ]


### PR DESCRIPTION
The current glob to regexp translation assumes a one-or-more match which is not necessarily correct. This commit fixes it and adds a test case with data from the SCC team.