### PR TITLE
Add --proxy-creds commandline option

### DIFF
--- a/cgyle/exceptions.py
+++ b/cgyle/exceptions.py
@@ -62,3 +62,21 @@ class CgylePodmanError(CgyleError):
     """
     Exception raised if podman call returns errors
     """
+
+
+class CgyleLoginError(CgyleError):
+    """
+    Exception raised if podman login has errors
+    """
+
+
+class CgyleCredentialsError(CgyleError):
+    """
+    Exception raised if the credentials format is invalid
+    """
+
+
+class CgyleThreadError(CgyleError):
+    """
+    A thread raised an exception
+    """


### PR DESCRIPTION
This allows to pass login credentials for the proxy registry. In case an authentication to the proxy registry server is required these credentials are used prior any pull from the proxy.