### PR TITLE
Added timer unit and service for registry.suse.com

### DIFF
--- a/package/python-cgyle-spec-template
+++ b/package/python-cgyle-spec-template
@@ -88,8 +88,16 @@ sed -e 's/docopt-ng.*/docopt = ">=0.6.2"/' -i pyproject.toml
 %install
 %{__python3} -m installer --destdir %{buildroot} %{?is_deb:--no-compile-bytecode} dist/*.whl
 
+install -d -m 755 %{buildroot}/usr/lib/systemd/system
+install -m 644 systemd/registry-suse-com.service \
+    %{buildroot}/usr/lib/systemd/system/registry-suse-com.service
+install -m 644 systemd/registry-suse-com.timer \
+    %{buildroot}/usr/lib/systemd/system/registry-suse-com.timer
+
 %files -n python%{python3_pkgversion}-cgyle
 %{python3_sitelib}/cgyle*
 %{_bindir}/cgyle
+%{_usr}/lib/systemd/system/registry-suse-com.timer
+%{_usr}/lib/systemd/system/registry-suse-com.service
 
 %changelog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ include = [
    { path = "package", format = "sdist" },
    { path = "test", format = "sdist" },
    { path = "tox.ini", format = "sdist" },
+   { path = "systemd", format = "sdist" },
 ]
 
 classifiers = [

--- a/systemd/registry-suse-com.service
+++ b/systemd/registry-suse-com.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Cache update for registry.suse.com
+
+[Service]
+Type=simple
+ExecStart=cgyle --updatecache local://distribution:/var/lib/registry --proxy-creds SCC_USER:SCC_PASS --registry-creds SCC_USER:SCC_PASS --from https://registry.suse.com --filter-policy SCC_POLICY --skip-policy-section free --apply

--- a/systemd/registry-suse-com.timer
+++ b/systemd/registry-suse-com.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Cache update timer for registry.suse.com
+Requires=network-online.target
+After=network.target syslog.target
+
+[Timer]
+Unit=registry-suse-com.service
+OnBootSec=1min
+OnUnitActiveSec=6h
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add systemd unit to run cgyle in local sync mode for a suse policy based sync from registry.suse.com into the default storage space of the distribution server below /var/lib/registry