### PR TITLE
psutil is required but was not added to the spec

### DIFF
--- a/package/python-cgyle-spec-template
+++ b/package/python-cgyle-spec-template
@@ -65,6 +65,7 @@ Requires:       python%{python3_pkgversion}-docopt
 Requires:       python%{python3_pkgversion}-requests
 Requires:       python%{python3_pkgversion}-setuptools
 Requires:       python%{python3_pkgversion}-PyYAML
+Requires:       python%{python3_pkgversion}-psutil
 Requires:       skopeo
 Requires:       podman
 


### PR DESCRIPTION
The psutil module requirement is listed in the pyproject.toml but was forgotten in the package spec. This commit fixes it