### PR TITLE
Allow to pass credentials for local proxy

### DIFF
--- a/cgyle/cli.py
+++ b/cgyle/cli.py
@@ -142,7 +142,8 @@ class Cli:
                 self.tls_proxy = False
                 self.cache = local_proxy.create_local_distribution_instance(
                     data_dir=self.local_distribution_cache,
-                    remote=self.from_registry
+                    remote=self.from_registry,
+                    proxy_creds=self.tls_registry_creds
                 )
 
             thread_pool = []

--- a/cgyle/proxy.py
+++ b/cgyle/proxy.py
@@ -151,7 +151,7 @@ class DistributionProxy:
         return format(self.pid)
 
     def create_local_distribution_instance(
-        self, data_dir: str, remote: str, port: int = 5000,
+        self, data_dir: str, remote: str, port: int = 7000,
         proxy_creds: str = ''
     ) -> str:
         self.registry_config = NamedTemporaryFile(prefix='cgyle_local_dist')

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -81,7 +81,8 @@ class TestCli:
             ]
             proxy.create_local_distribution_instance.assert_called_once_with(
                 data_dir='local://distribution:some',
-                remote='registry.opensuse.org'
+                remote='registry.opensuse.org',
+                proxy_creds=''
             )
             proxy.update_cache.assert_called_once_with(
                 ['latest'], False, '', ''


### PR DESCRIPTION
When providing --registry-creds in combination with a local proxy instance setup as --updatecache local://distribution:/some/path, make sure the provided credentials are used in the local distribution proxy configuration. Related to Issue #12