### PR TITLE
Support reading credentials from file

### DIFF
--- a/cgyle/catalog.py
+++ b/cgyle/catalog.py
@@ -23,6 +23,7 @@ from typing import (
     List, Dict
 )
 
+from cgyle.credentials import Credentials
 from cgyle.response import Response
 from cgyle.exceptions import (
     CgyleCatalogError,
@@ -60,6 +61,7 @@ class Catalog:
         """
         Read registry catalog using podman search
         """
+        username, password = Credentials.read(creds)
         result: List[str] = []
         server = server.replace('http://', '')
         server = server.replace('https://', '')
@@ -68,9 +70,9 @@ class Catalog:
             f'--tls-verify={format(tls_verify).lower()}',
             '--limit', '2147483647'
         ]
-        if creds:
+        if username and password:
             call_args += [
-                '--creds', creds
+                '--creds', f'{username}:{password}'
             ]
         call_args.append(
             f'{server}:/'

--- a/cgyle/cli.py
+++ b/cgyle/cli.py
@@ -58,10 +58,10 @@ options:
         from. It is expected that the referenced proxy registry
         uses this location in its configuration
 
-    --registry-creds=<user:pwd>
-        Contact given registry with the provided credentials
+    --registry-creds=<user:pwd|filename>
+        Contact given registry with the provided credentials.
 
-    --proxy-creds=<user:pwd>
+    --proxy-creds=<user:pwd|filename>
         Login to given proxy registry with the provided credentials
         using podman login
 

--- a/cgyle/credentials.py
+++ b/cgyle/credentials.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2024 SUSE Software Solutions Germany GmbH.  All rights reserved.
+#
+# This file is part of cgyle.
+#
+# cgyle is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cgyle is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cgyle.  If not, see <http://www.gnu.org/licenses/>
+#
+import os
+import yaml
+from typing import List
+
+from cgyle.exceptions import CgyleCredentialsError
+
+
+class Credentials:
+    """
+    Methods to handle credential sources
+    """
+    @staticmethod
+    def read(credentials_or_file: str) -> List[str]:
+        if os.path.isfile(credentials_or_file):
+            return Credentials.get_from_file(credentials_or_file)
+        return Credentials.get_credentials(credentials_or_file)
+
+    @staticmethod
+    def get_credentials(creds: str) -> List[str]:
+        try:
+            username, password = creds.split(':') if creds else ['', '']
+        except ValueError:
+            raise CgyleCredentialsError(
+                f'Invalid credentials, expected user:pass, got {creds}'
+            )
+        return [username, password]
+
+    @staticmethod
+    def get_from_file(filename: str) -> List[str]:
+        """
+        Read credentials from the given filename. It is expected that
+        the file is a yaml file containing the following information:
+
+        .. code:: yaml
+
+           scc:
+             username: user
+             password: pass
+        """
+        try:
+            with open(filename) as data:
+                config = yaml.safe_load(data)
+                return [config['scc']['username'], config['scc']['password']]
+        except Exception as issue:
+            raise CgyleCredentialsError(
+                f'Failed reading credentials from {filename}: {issue}'
+            )

--- a/test/data/credentials
+++ b/test/data/credentials
@@ -1,0 +1,3 @@
+scc:
+  username: user
+  password: pass

--- a/test/unit/credentials_test.py
+++ b/test/unit/credentials_test.py
@@ -1,0 +1,28 @@
+from unittest.mock import patch
+from pytest import raises
+from cgyle.credentials import Credentials
+from cgyle.exceptions import CgyleCredentialsError
+
+
+class TestCredentials:
+    @patch('os.path.isfile')
+    def test_get_credentials_from_string(self, mock_os_path_isfile):
+        mock_os_path_isfile.return_value = False
+        assert Credentials.read('user:pass') == ['user', 'pass']
+
+    @patch('os.path.isfile')
+    def test_get_credentials_from_file(self, mock_os_path_isfile):
+        mock_os_path_isfile.return_value = True
+        assert Credentials.read('../data/credentials') == ['user', 'pass']
+
+    @patch('os.path.isfile')
+    def test_get_credentials_from_string_invalid(self, mock_os_path_isfile):
+        mock_os_path_isfile.return_value = False
+        with raises(CgyleCredentialsError):
+            Credentials.read('bogus')
+
+    @patch('os.path.isfile')
+    def test_get_credentials_from_file_invalid(self, mock_os_path_isfile):
+        mock_os_path_isfile.return_value = True
+        with raises(CgyleCredentialsError):
+            Credentials.read('not_a_file')


### PR DESCRIPTION
Allow options --registry-creds/--proxy-creds to read from file. If the given value is a file in the system it will be used and read as a yaml file in the format of the rmt.conf file