### PR TITLE
Read credentials from file for SUSE service

### DIFF
--- a/systemd/registry-suse-com.service
+++ b/systemd/registry-suse-com.service
@@ -3,4 +3,4 @@ Description=Cache update for registry.suse.com
 
 [Service]
 Type=simple
-ExecStart=cgyle --updatecache local://distribution:/var/lib/registry --proxy-creds SCC_USER:SCC_PASS --registry-creds SCC_USER:SCC_PASS --from https://registry.suse.com --filter-policy /etc/rmt/access_policies.yml --skip-policy-section free --arch x86_64 --arch aarch64 --arch arm64 --arch amd64 --apply
+ExecStart=cgyle --updatecache local://distribution:/var/lib/registry --proxy-creds /etc/rmt.conf --registry-creds /etc/rmt.conf --from https://registry.suse.com --filter-policy /etc/rmt/access_policies.yml --skip-policy-section free --arch x86_64 --arch aarch64 --arch arm64 --arch amd64 --apply


### PR DESCRIPTION
Instead of passing user:pass credentials information on the commandline, use the /etc/rmt.conf file as input source for the credentials