### PR TITLE
Collect error logs into one file

### DIFF
--- a/cgyle/proxy.py
+++ b/cgyle/proxy.py
@@ -39,7 +39,7 @@ class DistributionProxy:
     configured as proxy
     """
     def __init__(self, server: str, container: str = '') -> None:
-        self.log_path = '/var/log/cgyle'
+        self.log_path = DistributionProxy.get_log_path()
         self.server = server.replace('http://', '')
         self.server = self.server.replace('https://', '')
         self.container = container
@@ -49,6 +49,10 @@ class DistributionProxy:
 
     def __enter__(self):
         return self
+
+    @staticmethod
+    def get_log_path():
+        return '/var/log/cgyle'
 
     def get_tags(
         self, tls_verify: bool = True, proxy_creds: str = '',

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -1,8 +1,9 @@
+import io
 import logging
 import sys
 from cgyle.cli import Cli
 from unittest.mock import (
-    patch, Mock, call
+    patch, Mock, call, MagicMock
 )
 from pytest import fixture
 
@@ -45,7 +46,8 @@ class TestCli:
         self.cli.dryrun = True
         self.cli.pattern = '.*'
         self.cli.policy = '../data/policy'
-        self.cli.update_cache()
+        with patch('builtins.open', create=True):
+            self.cli.update_cache()
         assert catalog.apply_filter.call_args_list == [
             call(['some-container'], []),
             call(['some-container'], ['.*'])
@@ -75,7 +77,8 @@ class TestCli:
         self.cli.local_distribution_cache = 'local://distribution:some'
         self.cli.max_requests = 1
         with self._caplog.at_level(logging.INFO):
-            self.cli.update_cache()
+            with patch('builtins.open', create=True):
+                self.cli.update_cache()
             assert mock_DistributionProxy.call_args_list == [
                 call('local://distribution:some'),
                 call(
@@ -94,8 +97,9 @@ class TestCli:
 
     @patch.object(Cli, '_get_catalog')
     @patch('concurrent.futures.as_completed')
+    @patch('cgyle.cli.DistributionProxy')
     def test_update_cache_thread_report_errors_on_thread_exceptions(
-        self, mock_futures_as_completed,
+        self, mock_DistributionProxy, mock_futures_as_completed,
         mock_get_catalog
     ):
         mock_get_catalog.return_value = ['some-container']
@@ -105,14 +109,59 @@ class TestCli:
         worker.exception = Mock(return_value='error')
         mock_futures_as_completed.return_value = [worker]
 
-        with self._caplog.at_level(logging.INFO):
+        with patch('builtins.open', create=True):
+            with self._caplog.at_level(logging.INFO):
+                self.cli.update_cache()
+
+    @patch('cgyle.cli.Catalog')
+    @patch('cgyle.cli.DistributionProxy')
+    @patch('os.walk')
+    def test_update_cache_collected_log(
+        self, mock_os_walk, mock_DistributionProxy, mock_Catalog
+    ):
+        catalog = Mock()
+        catalog.get_catalog.return_value = ['some/container/foo/bar']
+        mock_Catalog.return_value = catalog
+
+        mock_DistributionProxy.get_log_path.return_value = '/var/log/cgyle'
+
+        mock_os_walk.return_value = [
+            ('/var/log/cgyle/some/container/foo', [], ['bar.log', 'system.log']),
+            ('/var/log/cgyle/some/outside/catalog', [], ['some.log'])
+        ]
+        self.cli.dryrun = False
+        self.cli.use_podman_search = False
+        self.cli.local_distribution_cache = None
+
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
             self.cli.update_cache()
+            assert mock_open.call_args_list == [
+                call('/var/log/cgyle.log', 'a'),
+                call('/var/log/cgyle/some/container/foo/bar.log')
+            ]
+            mock_os_walk.assert_called_once_with('/var/log/cgyle')
+
+    @patch('cgyle.cli.Catalog')
+    @patch('cgyle.cli.DistributionProxy')
+    def test_update_cache_collected_log_IO_error(
+        self, mock_DistributionProxy, mock_Catalog
+    ):
+        mock_DistributionProxy.get_log_path.return_value = '/var/log/cgyle'
+        self.cli.dryrun = False
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.side_effect = IOError('issue')
+            with self._caplog.at_level(logging.ERROR):
+                self.cli.update_cache()
+            assert 'Failed to create logfile' in self._caplog.text
 
     @patch('cgyle.cli.Catalog')
     def test_get_catalog_request(self, mock_Catalog):
         catalog = Mock()
+        catalog.get_catalog.return_value = ['some/container']
         mock_Catalog.return_value = catalog
         self.cli.use_podman_search = False
+        self.cli.dryrun = True
         self.cli._get_catalog()
         catalog.get_catalog.assert_called_once_with(
             'registry.opensuse.org'
@@ -121,8 +170,10 @@ class TestCli:
     @patch('cgyle.cli.Catalog')
     def test_get_catalog_podman_search(self, mock_Catalog):
         catalog = Mock()
+        catalog.get_catalog_podman_search.return_value = ['some/container']
         mock_Catalog.return_value = catalog
         self.cli.use_podman_search = True
+        self.cli.dryrun = True
         self.cli._get_catalog()
         catalog.get_catalog_podman_search.assert_called_once_with(
             'registry.opensuse.org', True, ''


### PR DESCRIPTION
cgyle only keeps the log files of failed caching attempts and wipes the successful ones because there is no meaningful information in a successful caching process other than, the container was cached, which is an information that is still present by reading the log directory tree. The error information from all failed log files will now also be combined into one log file and appended to an eventually existing file.