### PR TITLE
Added min version requirements

### DIFF
--- a/package/python-cgyle-spec-template
+++ b/package/python-cgyle-spec-template
@@ -66,8 +66,8 @@ Requires:       python%{python3_pkgversion}-requests
 Requires:       python%{python3_pkgversion}-setuptools
 Requires:       python%{python3_pkgversion}-PyYAML
 Requires:       python%{python3_pkgversion}-psutil
-Requires:       skopeo
-Requires:       podman
+Requires:       skopeo >= 1.14
+Requires:       podman >= 4.8
 
 %description -n python%{python3_pkgversion}-cgyle
 Tooling for the pubcloud team. Allows to pre-populate


### PR DESCRIPTION
podman and skopeo has changed caller semantics in the past. Make sure a workable version is required by the package