### PR TITLE
Decouple use of registry container from network

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,17 @@ To run from source the following steps are needed:
 
 2. Create a local **distribution format** data tree mirror
 
+    Install or fetch the latest distribution registry container. For example:
+
+    .. code:: bash
+
+        podman pull docker.io/library/registry:latest
+
+    Next run cgyle which will run an instance of the above distribution registry
+    configured as a proxy for the `--from` target of the following cgyle call.
+    The container data tree produced inside of the container will be shared
+    with the host in the specified `my_mirror` directory.
+
     .. code:: bash
 
         poetry run cgyle --updatecache local://distribution:my_mirror --from https://registry.opensuse.org --filter '^opensuse/leap.*images.*toolbox' --apply

--- a/package/python-cgyle-spec-template
+++ b/package/python-cgyle-spec-template
@@ -68,6 +68,7 @@ Requires:       python%{python3_pkgversion}-PyYAML
 Requires:       python%{python3_pkgversion}-psutil
 Requires:       skopeo >= 1.14
 Requires:       podman >= 4.8
+Requires:       cgyle-oci-distribution >= 2.8.3
 
 %description -n python%{python3_pkgversion}-cgyle
 Tooling for the pubcloud team. Allows to pre-populate


### PR DESCRIPTION
When using cgyle in local://distribution mode, we run a container formerly named docker.io/library/registry:latest. If this container does not exist it will be fetched from the network. However, there are regions which doesn't allow this type of network access. To decouple the loading from the network we packaged the container, required it here in the spec for cgyle and referenced the container only as registry:latest.