### PR TITLE
Make sure cgyle runtime is limited

### DIFF
--- a/cgyle/proxy.py
+++ b/cgyle/proxy.py
@@ -166,14 +166,16 @@ class DistributionProxy:
                     )
                     if arch == 'all':
                         call_args = [
-                            'skopeo', 'copy', '--all',
-                            f'--src-tls-verify={format(tls_verify).lower()}'
+                            'skopeo', 'copy', '--all'
                         ]
                     else:
                         call_args = [
-                            'skopeo', '--override-arch', arch, 'copy',
-                            f'--src-tls-verify={format(tls_verify).lower()}'
+                            'skopeo', '--override-arch', arch, 'copy'
                         ]
+                    call_args += [
+                        '--retry-times', '5',
+                        f'--src-tls-verify={format(tls_verify).lower()}'
+                    ]
                     if username and password:
                         call_args += [
                             '--src-creds', f'{username}:{password}'

--- a/systemd/registry-suse-com.service
+++ b/systemd/registry-suse-com.service
@@ -5,4 +5,5 @@ Description=Cache update for registry.suse.com
 Type=simple
 User=_rmt
 Group=nginx
+RuntimeMaxSec=5h
 ExecStart=cgyle --updatecache local://distribution:/var/lib/rmt/public/repo/registry --proxy-creds /etc/rmt.conf --registry-creds /etc/rmt.conf --from https://registry.suse.com --filter-policy /etc/rmt/access_policies.yml --skip-policy-section free --arch x86_64 --arch aarch64 --arch arm64 --arch amd64 --apply

--- a/test/unit/proxy_test.py
+++ b/test/unit/proxy_test.py
@@ -66,7 +66,9 @@ class TestDistributionProxy:
             )
             mock_Popen.assert_called_once_with(
                 [
-                    'skopeo', 'copy', '--all', '--src-tls-verify=true',
+                    'skopeo', 'copy', '--all',
+                    '--retry-times', '5',
+                    '--src-tls-verify=true',
                     '--src-creds', 'user:pass',
                     'docker://server/container:latest',
                     'oci-archive:some_dir/container-latest-all.oci.tar:latest'
@@ -100,7 +102,7 @@ class TestDistributionProxy:
             mock_Popen.assert_called_once_with(
                 [
                     'skopeo', '--override-arch', 'x86_64',
-                    'copy', '--src-tls-verify=true',
+                    'copy', '--retry-times', '5', '--src-tls-verify=true',
                     '--src-creds', 'user:pass',
                     'docker://server/container:latest',
                     'oci-archive:some_dir/container-latest-x86_64.oci.tar:latest'
@@ -127,7 +129,9 @@ class TestDistributionProxy:
             self.proxy.update_cache(from_registry='some_registry')
             mock_Popen.assert_called_once_with(
                 [
-                    'skopeo', 'copy', '--all', '--src-tls-verify=true',
+                    'skopeo', 'copy', '--all',
+                    '--retry-times', '5',
+                    '--src-tls-verify=true',
                     'docker://server/container:latest',
                     'oci-archive:/dev/null:latest'
                 ], stdout=file_handle, stderr=file_handle


### PR DESCRIPTION
The sync process is run by a timer of 6h at the moment. If the service is still running when the timer kicks in, no restart will happen. In cgyle each container is fetched by its own skopeo copy process. We found situations in which that copy process receives an error and reconnects in a loop forever. As of today there is no way to tell skopeo to stop this iteration after some time and I also believe there is a bug in skopeo causing this because a simple restart of the cgyle service fixes the issue. For us it's important that the cgyle process is not blocked forever. Thus this commit suggest a max runtime controlled by systemd of 5h.