### PR TITLE
Limit the number of copy tries

### DIFF
--- a/cgyle/proxy.py
+++ b/cgyle/proxy.py
@@ -164,16 +164,18 @@ class DistributionProxy:
                     Path(os.path.dirname(log_name)).mkdir(
                         parents=True, exist_ok=True
                     )
-                    call_args = [
-                            'skopeo', 'copy', '--retry-times', '5'
-                    ]
                     if arch == 'all':
-                        call_args.append('--all')
+                        call_args = [
+                            'skopeo', 'copy', '--all'
+                        ]
                     else:
-                        call_args += ['--override-arch', arch]
-                    call_args.append(
+                        call_args = [
+                            'skopeo', '--override-arch', arch, 'copy'
+                        ]
+                    call_args += [
+                        '--retry-times', '5',
                         f'--src-tls-verify={format(tls_verify).lower()}'
-                    )
+                    ]
                     if username and password:
                         call_args += [
                             '--src-creds', f'{username}:{password}'

--- a/cgyle/proxy.py
+++ b/cgyle/proxy.py
@@ -164,16 +164,16 @@ class DistributionProxy:
                     Path(os.path.dirname(log_name)).mkdir(
                         parents=True, exist_ok=True
                     )
+                    call_args = [
+                            'skopeo', 'copy', '--retry-times', '5'
+                    ]
                     if arch == 'all':
-                        call_args = [
-                            'skopeo', 'copy', '--all',
-                            f'--src-tls-verify={format(tls_verify).lower()}'
-                        ]
+                        call_args.append('--all')
                     else:
-                        call_args = [
-                            'skopeo', '--override-arch', arch, 'copy',
-                            f'--src-tls-verify={format(tls_verify).lower()}'
-                        ]
+                        call_args += ['--override-arch', arch]
+                    call_args.append(
+                        f'--src-tls-verify={format(tls_verify).lower()}'
+                    )
                     if username and password:
                         call_args += [
                             '--src-creds', f'{username}:{password}'

--- a/test/unit/proxy_test.py
+++ b/test/unit/proxy_test.py
@@ -66,7 +66,9 @@ class TestDistributionProxy:
             )
             mock_Popen.assert_called_once_with(
                 [
-                    'skopeo', 'copy', '--all', '--src-tls-verify=true',
+                    'skopeo', 'copy', '--all',
+                    '--retry-times', '5',
+                    '--src-tls-verify=true',
                     '--src-creds', 'user:pass',
                     'docker://server/container:latest',
                     'oci-archive:some_dir/container-latest-all.oci.tar:latest'
@@ -100,7 +102,7 @@ class TestDistributionProxy:
             mock_Popen.assert_called_once_with(
                 [
                     'skopeo', '--override-arch', 'x86_64',
-                    'copy', '--src-tls-verify=true',
+                    'copy', '--retry-times', '5', '--src-tls-verify=true',
                     '--src-creds', 'user:pass',
                     'docker://server/container:latest',
                     'oci-archive:some_dir/container-latest-x86_64.oci.tar:latest'
@@ -127,7 +129,9 @@ class TestDistributionProxy:
             self.proxy.update_cache(from_registry='some_registry')
             mock_Popen.assert_called_once_with(
                 [
-                    'skopeo', 'copy', '--all', '--src-tls-verify=true',
+                    'skopeo', 'copy', '--all',
+                    '--retry-times', '5',
+                    '--src-tls-verify=true',
                     'docker://server/container:latest',
                     'oci-archive:/dev/null:latest'
                 ], stdout=file_handle, stderr=file_handle


### PR DESCRIPTION
skopeo may end up in an endless loop attempting to copy a specific container. This creates a problem in an automated environment such as cgyle potentially causing endless runtime. We limit the number of attempts we let skopeo take to copy a given container to 5. This allows us to move on and copy other containers. The next time cgyle runs we will try the previously failed container again.