### PR TITLE
Prevent thundering herd condition

### DIFF
--- a/systemd/registry-suse-com.service
+++ b/systemd/registry-suse-com.service
@@ -6,4 +6,5 @@ Type=simple
 User=_rmt
 Group=nginx
 RuntimeMaxSec=5h
+Restart=on-failure
 ExecStart=cgyle --updatecache local://distribution:/var/lib/rmt/public/repo/registry --proxy-creds /etc/rmt.conf --registry-creds /etc/rmt.conf --from https://registry.suse.com --filter-policy /etc/rmt/access_policies.yml --skip-policy-section free --arch x86_64 --arch aarch64 --arch arm64 --arch amd64 --apply

--- a/systemd/registry-suse-com.timer
+++ b/systemd/registry-suse-com.timer
@@ -7,6 +7,7 @@ After=network.target syslog.target
 Unit=registry-suse-com.service
 OnBootSec=1min
 OnUnitActiveSec=6h
+RandomizedDelaySec=3h
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The infrastructure runs several network bandwidth consuming processes potentially at the same time. To avoid this add a random delay on the timer. In addition we found that the hard stop in the service file hits us in the production environment. Let's add a restart condition on failure for  this case too
