### PR TITLE
Add delay time for service restart

### DIFF
--- a/systemd/registry-suse-com.service
+++ b/systemd/registry-suse-com.service
@@ -8,4 +8,5 @@ Group=nginx
 RuntimeMaxSec=5h
 Restart=on-failure
 ExecStartPre=/bin/bash -c "rm -rf /tmp/containers-user-$(id -u _rmt)"
+RestartSec=30s
 ExecStart=cgyle --updatecache local://distribution:/var/lib/rmt/public/repo/registry --proxy-creds /etc/rmt.conf --registry-creds /etc/rmt.conf --from https://registry.suse.com --filter-policy /etc/rmt/access_policies.yml --skip-policy-section free --arch x86_64 --arch aarch64 --arch arm64 --arch amd64 --apply


### PR DESCRIPTION
When cgyle starts the intermediate container to do the job and something fails, then cgyle exits with an exit code != 0. At the same time but disconnected from the cgyle process controlled by systemd the podman command running in the background ends and cleans up its resources. I can imagine that systemd tries to immediately start a new cgyle process while the podman cleanup of the former is not yet complete. A second run of the container on the same network port leads to conflict. This commit adds a restart delay to prevent this condition