### PR TITLE
Added a runtime cleanup prior service startup

### DIFF
--- a/systemd/registry-suse-com.service
+++ b/systemd/registry-suse-com.service
@@ -7,4 +7,5 @@ User=_rmt
 Group=nginx
 RuntimeMaxSec=5h
 Restart=on-failure
+ExecStartPre=/bin/bash -c "rm -rf /tmp/containers-user-$(id -u _rmt)"
 ExecStart=cgyle --updatecache local://distribution:/var/lib/rmt/public/repo/registry --proxy-creds /etc/rmt.conf --registry-creds /etc/rmt.conf --from https://registry.suse.com --filter-policy /etc/rmt/access_policies.yml --skip-policy-section free --arch x86_64 --arch aarch64 --arch arm64 --arch amd64 --apply


### PR DESCRIPTION
Older versions of podman uses the /tmp directory for the runroot of the rootless podman storage. This causes an issue if there are runtime artifacts from older container instances left on the system. To avoid a service startup error this commit adds a pre step to the systemd service which removes any stale /tmp/containers-user-ID directory.