### PR TITLE
Reduce max-requests to 1

### DIFF
--- a/systemd/registry-suse-com.service
+++ b/systemd/registry-suse-com.service
@@ -9,4 +9,4 @@ RuntimeMaxSec=5h
 Restart=on-failure
 ExecStartPre=/bin/bash -c "rm -rf /tmp/containers-user-$(id -u _rmt)"
 RestartSec=30s
-ExecStart=cgyle --updatecache local://distribution:/var/lib/rmt/public/repo/registry --proxy-creds /etc/rmt.conf --registry-creds /etc/rmt.conf --from https://registry.suse.com --filter-policy /etc/rmt/access_policies.yml --skip-policy-section free --arch x86_64 --arch aarch64 --arch arm64 --arch amd64 --apply
+ExecStart=cgyle --max-requests 1 --updatecache local://distribution:/var/lib/rmt/public/repo/registry --proxy-creds /etc/rmt.conf --registry-creds /etc/rmt.conf --from https://registry.suse.com --filter-policy /etc/rmt/access_policies.yml --skip-policy-section free --arch x86_64 --arch aarch64 --arch arm64 --arch amd64 --apply


### PR DESCRIPTION
For testing high load situations make sure there is only one active skopeo process