### PR TITLE
Limit the number of parallel copies

### DIFF
--- a/cgyle/proxy.py
+++ b/cgyle/proxy.py
@@ -174,6 +174,7 @@ class DistributionProxy:
                         ]
                     call_args += [
                         '--retry-times', '5',
+                        '--image-parallel-copies', '5',
                         f'--src-tls-verify={format(tls_verify).lower()}'
                     ]
                     if username and password:

--- a/package/python-cgyle-spec-template
+++ b/package/python-cgyle-spec-template
@@ -66,7 +66,7 @@ Requires:       python%{python3_pkgversion}-requests
 Requires:       python%{python3_pkgversion}-setuptools
 Requires:       python%{python3_pkgversion}-PyYAML
 Requires:       python%{python3_pkgversion}-psutil
-Requires:       skopeo >= 1.14
+Requires:       skopeo >= 1.17
 Requires:       podman >= 4.8
 Requires:       cgyle-oci-distribution >= 2.8.3
 

--- a/test/unit/proxy_test.py
+++ b/test/unit/proxy_test.py
@@ -68,6 +68,7 @@ class TestDistributionProxy:
                 [
                     'skopeo', 'copy', '--all',
                     '--retry-times', '5',
+                    '--image-parallel-copies', '5',
                     '--src-tls-verify=true',
                     '--src-creds', 'user:pass',
                     'docker://server/container:latest',
@@ -102,7 +103,9 @@ class TestDistributionProxy:
             mock_Popen.assert_called_once_with(
                 [
                     'skopeo', '--override-arch', 'x86_64',
-                    'copy', '--retry-times', '5', '--src-tls-verify=true',
+                    'copy', '--retry-times', '5',
+                    '--image-parallel-copies', '5',
+                    '--src-tls-verify=true',
                     '--src-creds', 'user:pass',
                     'docker://server/container:latest',
                     'oci-archive:some_dir/container-latest-x86_64.oci.tar:latest'
@@ -131,6 +134,7 @@ class TestDistributionProxy:
                 [
                     'skopeo', 'copy', '--all',
                     '--retry-times', '5',
+                    '--image-parallel-copies', '5',
                     '--src-tls-verify=true',
                     'docker://server/container:latest',
                     'oci-archive:/dev/null:latest'


### PR DESCRIPTION
Limit the number of simultaneous layer copies to 5. If we find out this is fixing the high load issue we can make this number a commandline option. This is related to Issue #34