### PR TITLE
Fixed tag list in case of an error

### DIFF
--- a/cgyle/proxy.py
+++ b/cgyle/proxy.py
@@ -255,6 +255,18 @@ class DistributionProxy:
                                     self.pid, log_name
                                 )
                             )
+                            # something went wrong with this container tag.
+                            # Rewrite the tag list and drop this tag from the list
+                            # such that it gets taken into account for the next
+                            # run of cgyle
+                            current_tag_list = []
+                            if os.path.exists(tag_log_name):
+                                with open(tag_log_name) as taglog:
+                                    current_tag_list = [tag.rstrip() for tag in taglog]
+                                with open(tag_log_name, 'w') as taglog:
+                                    for tag in current_tag_list:
+                                        if tag != tagname:
+                                            taglog.write(f'{tag}{os.linesep}')
                         else:
                             os.unlink(log_name)
                         logging.info(f'[{self.pid}]: [Done]')


### PR DESCRIPTION
cgyle fetches the current tag list and compares it with an eventually existing prior taglist. The difference in tags is then synced with the exception of 'latest' which is always synced. If in this process a tag cannot be fetched due to some error, the tag list still listed this tag as being processed. In the next run of cgyle this tag is not tried to be fetched again. This commit adds code to update the tag list in case the fetching of the tag has failed for some reason such that in a subsequent call of cgyle this tag is tried to be fetched again.