### PR TITLE
Allow sync of attestation tags

### DIFF
--- a/cgyle/cli.py
+++ b/cgyle/cli.py
@@ -29,6 +29,7 @@ usage: cgyle -h | --help
            [--tls-verify-registry=<BOOL>]
            [--max-requests=<number>]
            [--remove-signatures]
+           [--with-attestation]
        cgyle --list-archs
 
 options:
@@ -81,6 +82,9 @@ options:
     --remove-signatures
         Do not copy signatures. Necessary when copying a signed image
         to a destination which does not support signatures
+
+    --with-attestation
+        Do not skip tags ending with .att
 
     --tls-verify-proxy=BOOL
         Contact given proxy location without TLS [default: True]
@@ -145,6 +149,7 @@ class Cli:
         self.push_oci = self.arguments['--push-oci'] or ''
         self.tls_push_oci_creds = self.arguments['--push-oci-creds'] or ''
         self.remove_signatures = bool(self.arguments['--remove-signatures'])
+        self.with_attestation = bool(self.arguments['--with-attestation'])
         self.catalog: List[str] = []
 
         self.local_distribution_cache = ''
@@ -202,7 +207,8 @@ class Cli:
                                 self.tls_push_oci_creds,
                                 self.tls_proxy_creds,
                                 self.use_archs,
-                                self.remove_signatures
+                                self.remove_signatures,
+                                self.with_attestation
                             )
                         )
 

--- a/cgyle/proxy.py
+++ b/cgyle/proxy.py
@@ -56,7 +56,8 @@ class DistributionProxy:
 
     def get_tags(
         self, tls_verify: bool = True, proxy_creds: str = '',
-        arch: str = '', tag_log_name: str = ''
+        arch: str = '', tag_log_name: str = '',
+        with_attestation: bool = False
     ) -> List[str]:
         username, password = Credentials.read(proxy_creds)
         call_args = [
@@ -112,18 +113,10 @@ class DistributionProxy:
             )
         result_tag_list = []
         for tag in tag_list:
-            # signed images contains .sig/.att tag names which references
-            # a specific SHA-256 digest of the image that got signed.
-            # We could take this information to verify the image prior
-            # pulling it but I believe there is enough trust established
-            # with the authentication against the origin registry server.
-            # From a mirror perspective we want to mirror the tag names
-            # and not the digests because users can do something with
-            # names but nothing with digests. In addition the setup of
-            # the origin registry server maintains the tag names to be
-            # immutable together with the signing. Thus we ignore
-            # repo tags ending with .sig/.att
-            if not tag.endswith('.sig') and not tag.endswith('.att'):
+            if tag.endswith('.att') and with_attestation:
+                # Add attestation tag for custom attributes, e.g sboms
+                result_tag_list.append(tag)
+            elif not tag.endswith('.sig') and not tag.endswith('.att'):
                 result_tag_list.append(tag)
         if tag_log_name:
             with open(tag_log_name, 'w') as taglog:
@@ -136,7 +129,8 @@ class DistributionProxy:
         self, from_registry: str, tls_verify: bool = True,
         store_oci: str = '', push_oci: str = '', push_oci_creds: str = '',
         proxy_creds: str = '', use_archs: List[str] = [],
-        remove_signatures: bool = False
+        remove_signatures: bool = False,
+        with_attestation: bool = False
     ) -> None:
         """
         Trigger a cache update of the container
@@ -173,7 +167,10 @@ class DistributionProxy:
                         prior_tag_list = [tag.rstrip() for tag in taglog]
                 tag_list = DistributionProxy(
                     from_registry, self.container
-                ).get_tags(tls_verify, proxy_creds, arch, tag_log_name)
+                ).get_tags(
+                    tls_verify, proxy_creds, arch, tag_log_name,
+                    with_attestation
+                )
                 tag_list = \
                     [tag for tag in tag_list if tag not in prior_tag_list]
                 for tagname in tag_list:

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -92,7 +92,8 @@ class TestCli:
                 proxy_creds=''
             )
             proxy.update_cache.assert_called_once_with(
-                'registry.opensuse.org', False, '', '', '', '', [], False
+                'registry.opensuse.org', False, '', '', '', '', [],
+                False, False
             )
 
     @patch.object(Cli, '_get_catalog')

--- a/test/unit/proxy_test.py
+++ b/test/unit/proxy_test.py
@@ -401,7 +401,9 @@ class TestDistributionProxy:
         first.communicate.return_value = ['', '']
         second = Mock()
         second.returncode = 0
-        second.communicate.return_value = [b'tag1\ntag2', b'']
+        second.communicate.return_value = [
+            b'tag1\ntag2\nsome.sig\nsome.att', b''
+        ]
         skopeos = [
             second, first
         ]
@@ -412,7 +414,13 @@ class TestDistributionProxy:
         mock_Popen.side_effect = calls
         with patch('builtins.open', create=True):
             assert self.proxy.get_tags(
-                True, 'user:pass', 'amd64', 'some-log-file'
+                True, 'user:pass', 'amd64', 'some-log-file', True
+            ) == ['tag1', 'tag2', 'some.att']
+            skopeos = [
+                second, first
+            ]
+            assert self.proxy.get_tags(
+                True, 'user:pass', 'amd64', 'some-log-file', False
             ) == ['tag1', 'tag2']
 
     @patch('cgyle.proxy.subprocess.Popen')

--- a/tools/suse2ecr
+++ b/tools/suse2ecr
@@ -113,5 +113,6 @@ if [ ! "${argDryRun}" ];then
         --push-oci "${push_registry}" \
         --push-oci-creds=AWS:"${push_creds}" \
         --filter-policy "${filter}" \
+        --with-attestation \
         --apply
 fi


### PR DESCRIPTION
Attestation tags (.att) are used to provide SBOM information for containers. By default we do not sync them. The new
option --with-attestation allows to turn it on