### PR TITLE
Add put-repository-catalog-data in suse2ecr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ setup:
 
 check: setup
 	# shell code checks
-	bash -c 'shellcheck tools/suse2ecr -s bash'
+	bash -c 'shellcheck tools/cgyle2ecr -s bash'
 	# python flake tests
 	poetry run flake8 --statistics -j auto --count cgyle
 	poetry run flake8 --statistics -j auto --count test/unit

--- a/package/python-cgyle-spec-template
+++ b/package/python-cgyle-spec-template
@@ -89,30 +89,35 @@ sed -e 's/docopt-ng.*/docopt = ">=0.6.2"/' -i pyproject.toml
 %install
 %{__python3} -m installer --destdir %{buildroot} %{?is_deb:--no-compile-bytecode} dist/*.whl
 
-install -d -m 755 %{buildroot}/usr/sbin
+install -d -m 755 %{buildroot}/etc/cgyle2ecrmetadata.d
+install -d -m 755 %{buildroot}/%{_sbindir}
 install -d -m 755 %{buildroot}/etc
+
+# This is data used in the suse public cloud infrastructure
+# If this needs to change a conversation with the SRE team
+# is required first !
 install -m 755 tools/cgyle-pubcloud-infra-cleanup \
-    %{buildroot}/usr/sbin
-install -m 644 tools/suse2ecr_policy.yml \
-    %{buildroot}/etc
-install -m 644 tools/bci2ecr_policy.yml \
-    %{buildroot}/etc
-install -m 755 tools/suse2ecr \
-    %{buildroot}/usr/sbin
+    %{buildroot}/%{_sbindir}
 install -d -m 755 %{buildroot}/usr/lib/systemd/system
 install -m 644 systemd/registry-suse-com.service \
     %{buildroot}/usr/lib/systemd/system/registry-suse-com.service
 install -m 644 systemd/registry-suse-com.timer \
     %{buildroot}/usr/lib/systemd/system/registry-suse-com.timer
 
+install -m 755 tools/cgyle2ecr \
+    %{buildroot}/%{_sbindir}
+
 %files -n python%{python3_pkgversion}-cgyle
+%dir %{_sysconfdir}/cgyle2ecrmetadata.d
 %{python3_sitelib}/cgyle*
 %{_bindir}/cgyle
+%{_sbindir}/cgyle2ecr
+
+# This is data used in the suse public cloud infrastructure
+# If this needs to change a conversation with the SRE team
+# is required first !
 %{_sbindir}/cgyle-pubcloud-infra-cleanup
-%{_sbindir}/suse2ecr
 %config %{_usr}/lib/systemd/system/registry-suse-com.timer
 %config %{_usr}/lib/systemd/system/registry-suse-com.service
-%config /etc/suse2ecr_policy.yml
-%config /etc/bci2ecr_policy.yml
 
 %changelog

--- a/tools/bci2ecr_policy.yml
+++ b/tools/bci2ecr_policy.yml
@@ -1,4 +1,0 @@
----
-free:
-- bci/bci-base
-- bci/bci-minimal

--- a/tools/cgyle2ecr
+++ b/tools/cgyle2ecr
@@ -3,8 +3,12 @@
 
 set -e
 
+export catalog_dir=/etc/cgyle2ecrmetadata.d
+export ecr="ecr"
+export alias=""
+
 function usage {
-    echo "suse2ecr --aws-ecr <url> --filter-policy <file>"
+    echo "cgyle2ecr --registry <url> --aws-ecr <url> --filter-policy <file>"
     echo "  [--public]"
     echo "     push to public ECR"
     echo "  [--aws-profile <name>]"
@@ -13,15 +17,29 @@ function usage {
     echo "     ECR alias name to use, by default taken from sync path"
     echo "  [--dry-run]"
     echo "     apply filter policy only and print list of matches"
+    echo "  [--debug]"
+    echo "     enable debug information"
     exit 1
+}
+
+function get_source_catalog {
+    local repo=$1
+    local catalog
+    repo=$(echo "${repo}" | tr / _)
+    catalog="${catalog_dir}/${repo}.json"
+    if [ -f "${catalog}" ];then
+        echo "file://${catalog}"
+    fi
 }
 
 ARGUMENT_LIST=(
     "aws-profile:"
     "aws-ecr:"
+    "registry:"
     "filter-policy:"
     "alias:"
     "dry-run"
+    "debug"
     "public"
 )
 
@@ -49,6 +67,11 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
 
+        --registry)
+            argRegistry=$2
+            shift 2
+            ;;
+
         --filter-policy)
             argFilterPolicy=$2
             shift 2
@@ -61,6 +84,11 @@ while [[ $# -gt 0 ]]; do
 
         --dry-run)
             argDryRun=1
+            shift
+            ;;
+
+        --debug)
+            argDebug=1
             shift
             ;;
 
@@ -80,12 +108,14 @@ if [ ! "${argAWSECR}" ] || \
     usage
 fi
 
-registry=https://registry.suse.com
+if [ "${argDebug}" ];then
+    set -x
+fi
+
+registry=${argRegistry}
 profile=${argAWSProfile}
 push_registry=${argAWSECR}
 filter=${argFilterPolicy}
-ecr="ecr"
-alias=""
 if [ "${argPublic}" ];then
     ecr="ecr-public"
 fi
@@ -121,10 +151,14 @@ cgyle \
 
     echo "${repo}"
     if [ ! "${argDryRun}" ];then
-        ${aws_ecr} describe-repositories \
-            --repository-names "${repo}" &> /dev/null || \
-        ${aws_ecr} create-repository \
-            --repository-name "${repo}"
+        if ! ${aws_ecr} describe-repositories \
+            --repository-names "${repo}" &> /dev/null
+        then
+            ${aws_ecr} create-repository \
+                --repository-name "${repo}"
+            ${aws_ecr} put-repository-catalog-data \
+                --cli-input-json "$(get_source_catalog "${repo}")"
+        fi
     fi
 done
 

--- a/tools/suse2ecr_policy.yml
+++ b/tools/suse2ecr_policy.yml
@@ -1,4 +1,0 @@
----
-free:
-- bci/bci-minimal
-- bci/bci-base


### PR DESCRIPTION
So far suse2ecr created the repository and synced the containers. If the repository needs to be created, the repository catalog information like description, usage and more was not set. This commit adds the required API calls to set this information after the repository was created.