### PR TITLE
Add support for tag filtering

### DIFF
--- a/cgyle/catalog.py
+++ b/cgyle/catalog.py
@@ -133,21 +133,34 @@ class Catalog:
                     )
         return sorted(result)
 
+    def get_tag_filter(self, policy_file: str) -> Dict[str, str]:
+        try:
+            with open(policy_file) as policy_fd:
+                policy = yaml.safe_load(policy_fd)
+                return policy.get('tagfilter', {})
+        except Exception as issue:
+            raise CgyleError(
+                f'Failed to open {policy_file}: {issue}'
+            )
+
     def translate_policy(
         self, policy_file: str,
         skip_sections: List[str] = [], use_archs: List[str] = []
     ) -> List[str]:
+        # By default, skip tagfilter section as it is not
+        # relevant for to policy evaluation of the catalog
+        skip_sections.append('tagfilter')
         result: List[str] = []
         skip_archs = []
         if use_archs:
             skip_archs = self.archs
             skip_archs = list(filter(lambda i: i not in use_archs, skip_archs))
         try:
-            with open(policy_file) as policy:
-                policy_dict = yaml.safe_load(policy)
-                for category in policy_dict:
+            with open(policy_file) as policy_fd:
+                policy = yaml.safe_load(policy_fd)
+                for category in policy:
                     if category not in skip_sections:
-                        for pattern in policy_dict.get(category):
+                        for pattern in policy.get(category):
                             if not next(
                                 (arch for arch in skip_archs if arch in pattern), None
                             ):

--- a/cgyle/cli.py
+++ b/cgyle/cli.py
@@ -197,9 +197,12 @@ class Cli:
                 if self.dryrun:
                     logging.info(f'Proxy: [{self.cache}]:')
                 for container in self._get_catalog():
+                    tag_filter = self._get_filter_expression(container)
                     count += 1
                     if self.dryrun:
-                        logging.info(f'  ({count}) - {container}')
+                        logging.info(
+                            f'  ({count}) - {container}[{tag_filter or "all"}]'
+                        )
                     else:
                         proxy = DistributionProxy(self.cache, container)
                         stack.push(proxy)
@@ -215,7 +218,8 @@ class Cli:
                                 self.use_archs,
                                 self.remove_signatures,
                                 self.with_attestation,
-                                self.ecr_alias
+                                self.ecr_alias,
+                                tag_filter
                             )
                         )
 
@@ -254,6 +258,15 @@ class Cli:
                                             collect_fd.write(os.linesep)
             except IOError as issue:
                 logging.error(f'Failed to create logfile: {issue}')
+
+    def _get_filter_expression(self, container: str) -> str:
+        filter_expression = ''
+        if self.policy:
+            catalog = Catalog()
+            filter_expression = catalog.get_tag_filter(
+                self.policy
+            ).get(container, '')
+        return filter_expression
 
     def _get_catalog(self) -> List[str]:
         catalog = Catalog()

--- a/cgyle/proxy.py
+++ b/cgyle/proxy.py
@@ -16,6 +16,7 @@
 # along with cgyle.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import re
 import yaml
 import json
 import time
@@ -55,9 +56,13 @@ class DistributionProxy:
         return '/var/log/cgyle'
 
     def get_tags(
-        self, tls_verify: bool = True, proxy_creds: str = '',
-        arch: str = '', tag_log_name: str = '',
-        with_attestation: bool = False
+        self,
+        tls_verify: bool = True,
+        proxy_creds: str = '',
+        arch: str = '',
+        tag_log_name: str = '',
+        with_attestation: bool = False,
+        filter_expression: str = ''
     ) -> List[str]:
         username, password = Credentials.read(proxy_creds)
         call_args = [
@@ -123,6 +128,9 @@ class DistributionProxy:
                 for tag in result_tag_list:
                     if tag != 'latest':
                         taglog.write(f'{tag}{os.linesep}')
+        if filter_expression:
+            regexp = re.compile(filter_expression)
+            result_tag_list = list(filter(regexp.search, result_tag_list))
         return result_tag_list
 
     def update_cache(
@@ -131,7 +139,8 @@ class DistributionProxy:
         proxy_creds: str = '', use_archs: List[str] = [],
         remove_signatures: bool = False,
         with_attestation: bool = False,
-        ecr_alias: str = ''
+        ecr_alias: str = '',
+        filter_expression: str = ''
     ) -> None:
         """
         Trigger a cache update of the container
@@ -170,7 +179,7 @@ class DistributionProxy:
                     from_registry, self.container
                 ).get_tags(
                     tls_verify, proxy_creds, arch, tag_log_name,
-                    with_attestation
+                    with_attestation, filter_expression
                 )
                 tag_list = \
                     [tag for tag in tag_list if tag not in prior_tag_list]

--- a/test/data/policy
+++ b/test/data/policy
@@ -6,3 +6,6 @@ free:
 - foo/*/bar/**
 - foo/*/x86_64/bar/**
 - foo/s390x/bar
+
+tagfilter:
+  bci/**: ^(?!16.1)

--- a/test/unit/catalog_test.py
+++ b/test/unit/catalog_test.py
@@ -135,3 +135,19 @@ class TestCatalog:
             mock_open.side_effect = Exception
             with raises(CgyleError):
                 self.catalog.translate_policy('bogus', use_archs=['x86_64'])
+
+    def test_get_tag_filter(self):
+        assert self.catalog.get_tag_filter(
+            '../data/policy'
+        ) == {
+            'bci/**': '^(?!16.1)'
+        }
+        assert self.catalog.get_tag_filter(
+            '../data/policy.test'
+        ) == {}
+
+    def test_get_tag_filter_open_failed(self):
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.side_effect = Exception
+            with raises(CgyleError):
+                self.catalog.get_tag_filter('bogus')

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -93,7 +93,7 @@ class TestCli:
             )
             proxy.update_cache.assert_called_once_with(
                 'registry.opensuse.org', False, '', '', '', '', [],
-                False, False, ''
+                False, False, '', ''
             )
 
     @patch.object(Cli, '_get_catalog')

--- a/test/unit/proxy_test.py
+++ b/test/unit/proxy_test.py
@@ -465,6 +465,31 @@ class TestDistributionProxy:
 
     @patch('cgyle.proxy.subprocess.Popen')
     @patch('os.unlink')
+    def test_get_tags_filter_expression(self, mock_os_unlink, mock_Popen):
+        first = Mock()
+        first.returncode = 1
+        first.communicate.return_value = ['', '']
+        second = Mock()
+        second.returncode = 0
+        second.communicate.return_value = [
+            b'16.0\n16.1\n16.1.2\n15.2\n16.0.122', b''
+        ]
+        skopeos = [
+            second, first
+        ]
+
+        def calls(argc, **argv):
+            return skopeos.pop()
+
+        mock_Popen.side_effect = calls
+        with patch('builtins.open', create=True):
+            assert self.proxy.get_tags(
+                True, 'user:pass', 'amd64', 'some-log-file', True,
+                filter_expression='^(?!16.1)'
+            ) == ['16.0', '15.2', '16.0.122']
+
+    @patch('cgyle.proxy.subprocess.Popen')
+    @patch('os.unlink')
     def test_get_tags_podman_search_on_invalid_container_arch(
         self, mock_os_unlink, mock_Popen
     ):

--- a/tools/cgyle2ecr
+++ b/tools/cgyle2ecr
@@ -138,8 +138,8 @@ push_creds=$(
 # Create repos on the remote ECR
 cgyle \
     --updatecache "${registry}" --from "${registry}" \
-    --filter-policy "${filter}" \
-2>&1 | grep -v INFO:Proxy: | cut -f2- -d- | while read -r repo; do
+    --filter-policy "${filter}" 2>&1 |\
+grep -v INFO:Proxy: | cut -f2- -d- | cut -f1 -d\[ | while read -r repo;do
     # we searched for containers in the given filter-policy.
     # The result is a path. The first element of that path is
     # the custom alias name of the ECR registry in AWS. The


### PR DESCRIPTION
Allow to add a tag filter expression (python regular expression) for each container pattern as part of a dedicated tagfilter section in the policy file. This Fixes #48