### PR TITLE
Refactor catalog request

### DIFF
--- a/cgyle/catalog.py
+++ b/cgyle/catalog.py
@@ -15,12 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with cgyle.  If not, see <http://www.gnu.org/licenses/>
 #
-import os
 import re
 import yaml
-import logging
-import time
-import subprocess
 from typing import (
     List, Dict
 )
@@ -30,8 +26,6 @@ from cgyle.response import Response
 from cgyle.exceptions import (
     CgyleError,
     CgyleCatalogError,
-    CgyleCommandError,
-    CgylePodmanError,
     CgyleFilterExpressionError
 )
 
@@ -42,80 +36,60 @@ class Catalog:
     """
     def __init__(self) -> None:
         self.archs = Catalog.get_arch_list()
-        self.response = Response()
 
-    def get_catalog(self, server: str) -> List[str]:
+    def get_catalog(self, server: str, creds: str = '') -> List[str]:
         """
         Read registry catalog from a v2 registry format
         """
-        catalog_dict: Dict[str, List[str]] = self.response.get(
-            f'{server}/v2/_catalog'
-        )
-        try:
-            return catalog_dict['repositories']
-        except KeyError:
-            raise CgyleCatalogError(
-                f'Unexpected catalog response: {catalog_dict}'
-            )
-
-    def get_catalog_podman_search(
-        self, server: str, tls_verify: bool = True, creds: str = ''
-    ) -> List[str]:
-        """
-        Read registry catalog using podman search
-        """
+        remote = Response()
         username, password = Credentials.read(creds)
-        result: List[str] = []
-        server = server.replace('http://', '')
-        server = server.replace('https://', '')
-        call_args = [
-            'podman', 'search',
-            f'--tls-verify={format(tls_verify).lower()}',
-            '--limit', '2147483647'
-        ]
-        if username and password:
-            call_args += [
-                '--creds', f'{username}:{password}'
-            ]
-        call_args.append(
-            f'{server}:/'
+        target = f'{server}/v2/_catalog'
+        challenge = remote.get_auth_challenge(target)
+        token = ''
+        headers = {}
+        if challenge:
+            realm, service = remote.extract_bearer_parameters(challenge)
+            if not realm or not service:
+                raise CgyleCatalogError(
+                    f'Failed to parse authentication challenge: {challenge}'
+                )
+            token_data = remote.fetch(
+                realm,
+                parameters={
+                    'service': service,
+                    'scope': 'registry:catalog:*'
+                },
+                user=username,
+                password=password
+            )
+            token = \
+                token_data.get('token') or token_data.get('access_token') or ''
+            if not token:
+                raise CgyleCatalogError(
+                    f'Failed to acquire token from {token_data}'
+                )
+        if token:
+            headers = {
+                'Authorization': f'Bearer {token}'
+            }
+        catalog_data = remote.fetch(
+            target, headers=headers
         )
-        retry = 0
-        max_retry = 10
-        catalog_issue = 'unknown'
-        while retry < max_retry:
-            try:
-                self.podman = subprocess.Popen(
-                    call_args,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE
-                )
-                output, error = self.podman.communicate()
-                if error and self.podman.returncode != 0:
-                    message = '[{}]: podman search failed with: {}'.format(
-                        retry + 1, error.decode().strip()
-                    )
-                    logging.info(message)
-                    raise CgylePodmanError(message)
-                if output:
-                    result = []
-                    for line in output.decode().split(os.linesep):
-                        server, slash, container = line.partition(os.sep)
-                        container = container.strip()
-                        if container:
-                            result.append(container)
-                break
-            except CgylePodmanError as issue:
-                catalog_issue = format(issue)
-                time.sleep(2)
-                retry += 1
-            except Exception as issue:
-                raise CgyleCommandError(
-                    f'Failed to call podman search: {issue}'
-                )
-        if retry >= max_retry:
-            raise CgylePodmanError(catalog_issue)
-        return result
+        if errors := catalog_data.get('errors'):
+            raise CgyleCatalogError(
+                f'Failed to acquire catalog {errors}'
+            )
+        result = catalog_data.get('repositories')
+        link = catalog_data.get('Link')
+        while link:
+            link = link.replace('<', '').replace('>', '')
+            target = f'{server}{link}'
+            data = remote.fetch(
+                target, headers=headers
+            )
+            result += catalog_data.get('repositories', [])
+            link = data.get('Link')
+        return sorted(result) if result else []
 
     def apply_filter(
         self, catalog: List[str], rules: List[str]

--- a/cgyle/cli.py
+++ b/cgyle/cli.py
@@ -120,7 +120,7 @@ from cgyle.catalog import Catalog
 
 logging.basicConfig(
     format='%(levelname)s:%(message)s',
-    level=logging.DEBUG
+    level=logging.INFO
 )
 
 
@@ -161,10 +161,6 @@ class Cli:
         self.local_distribution_cache = ''
         if self.cache and self.cache.startswith('local://distribution'):
             self.local_distribution_cache = self.cache.split(':')[2]
-
-        self.use_podman_search = False
-        if self.tls_registry_creds or self.tls_registry:
-            self.use_podman_search = True
 
         if process:
             if self.list_archs:
@@ -270,13 +266,9 @@ class Cli:
 
     def _get_catalog(self) -> List[str]:
         catalog = Catalog()
-        if self.use_podman_search:
-            result = catalog.get_catalog_podman_search(
-                self.from_registry, self.tls_registry,
-                self.tls_registry_creds
-            )
-        else:
-            result = catalog.get_catalog(self.from_registry)
+        result = catalog.get_catalog(
+            self.from_registry, self.tls_registry_creds
+        )
 
         if self.policy:
             result = catalog.apply_filter(

--- a/cgyle/response.py
+++ b/cgyle/response.py
@@ -15,14 +15,16 @@
 # You should have received a copy of the GNU General Public License
 # along with cgyle.  If not, see <http://www.gnu.org/licenses/>
 #
+import re
 import json
 import requests
 import requests.packages.urllib3
-
-from cgyle.exceptions import (
-    CgyleJsonError,
-    CgyleRequestError
+from urllib.parse import urlencode
+from typing import (
+    Optional, Any
 )
+
+from cgyle.exceptions import CgyleRequestError
 
 
 class Response:
@@ -32,23 +34,56 @@ class Response:
     def __init__(self) -> None:
         requests.packages.urllib3.disable_warnings()
 
-    def get(self, uri: str) -> dict:
+    def get_auth_challenge(self, target: str) -> Optional[str]:
         """
-        Send GET request and expect JSON
+        Retrieve Www-Authenticate information from
+        request target header
+        """
+        return self.fetch(target).get('www-authenticate')
+
+    def extract_bearer_parameters(
+        self, challenge: str
+    ) -> tuple[Optional[str], Optional[str]]:
+        realm = re.search(r'realm="([^"]+)"', challenge, re.IGNORECASE)
+        service = re.search(r'service="([^"]+)"', challenge, re.IGNORECASE)
+        return (
+            realm.group(1) if realm else None,
+            service.group(1) if service else None,
+        )
+
+    def fetch(
+        self,
+        target: str,
+        parameters: Optional[dict[str, str]] = None,
+        headers: Optional[dict[str, str]] = None,
+        user: str = '',
+        password: str = '',
+        timeout: int = 300
+    ) -> dict[str, Any]:
+        """
+        Fetch request content and header, default timeout set to 300sec
         """
         try:
-            response = requests.request(
-                'GET', uri, stream=True, data=None, headers=None
+            url = target
+            if parameters:
+                url = f'{target}?{urlencode(parameters)}'
+            if user:
+                response = requests.get(
+                    url,
+                    headers=headers or {},
+                    auth=(user, password),
+                    timeout=timeout
+                )
+            else:
+                response = requests.get(url, headers=headers or {})
+            result = json.loads(response.content)
+            result.update(response.headers)
+            return result
+        except requests.exceptions.Timeout:
+            raise CgyleRequestError(
+                f'Request to {url} timed out'
             )
         except Exception as issue:
             raise CgyleRequestError(
-                f'Failed to handle request: {issue}'
-            )
-        try:
-            return json.loads(response.content)
-        except Exception:
-            raise CgyleJsonError(
-                'Failed to load response into JSON format: {}'.format(
-                    response.content.decode()
-                )
+                f'Failed to fetch request data: {issue}'
             )

--- a/test/unit/catalog_test.py
+++ b/test/unit/catalog_test.py
@@ -1,13 +1,10 @@
-from unittest.mock import (
-    patch, Mock
-)
+from unittest.mock import patch
 from pytest import raises
 from cgyle.catalog import Catalog
+from cgyle.response import Response
 from cgyle.exceptions import (
     CgyleError,
     CgyleCatalogError,
-    CgylePodmanError,
-    CgyleCommandError,
     CgyleFilterExpressionError
 )
 
@@ -19,56 +16,66 @@ class TestCatalog:
     def setup_method(self, cls):
         self.setup()
 
-    @patch('cgyle.catalog.Response.get')
-    def test_get_catalog(self, mock_Response_get):
-        mock_Response_get.return_value = {'repositories': ['name']}
-        assert self.catalog.get_catalog(
-            'https://registry.opensuse.org'
-        ) == ['name']
+    @patch.object(Response, 'get_auth_challenge')
+    @patch.object(Response, 'extract_bearer_parameters')
+    @patch.object(Response, 'fetch')
+    def test_get_catalog(
+        self,
+        mock_fetch,
+        mock_extract_bearer_parameters,
+        mock_get_auth_challenge
+    ):
+        def fetch(
+            target, parameters=None, headers=None, user='', password=''
+        ):
+            if 'some_link' in target:
+                return {}
+            else:
+                return {
+                    'repositories': ['name'],
+                    'token': 'some',
+                    'Link': 'some_link'
+                }
 
-    @patch('cgyle.catalog.Response.get')
-    def test_get_catalog_raises(self, mock_Response_get):
-        mock_Response_get.return_value = {'errors': ['some']}
+        mock_extract_bearer_parameters.return_value = ('realm', 'service')
+        mock_get_auth_challenge.return_value = 'some'
+        mock_fetch.side_effect = fetch
+        assert self.catalog.get_catalog(
+            'https://registry.opensuse.org', 'user:pass'
+        ) == ['name', 'name']
+
+    @patch.object(Response, 'get_auth_challenge')
+    @patch.object(Response, 'extract_bearer_parameters')
+    @patch.object(Response, 'fetch')
+    def test_get_catalog_raises(
+        self,
+        mock_fetch,
+        mock_extract_bearer_parameters,
+        mock_get_auth_challenge
+    ):
+        mock_get_auth_challenge.return_value = 'some'
+        mock_extract_bearer_parameters.return_value = ('', '')
         with raises(CgyleCatalogError):
             self.catalog.get_catalog(
                 'https://registry.opensuse.org'
             )
-
-    @patch('time.sleep')
-    @patch('cgyle.proxy.subprocess.Popen')
-    def test_get_catalog_podman_search_raises_with_error(self, mock_Popen, mock_time):
-        podman = Mock()
-        podman.communicate.return_value = (b'output', b'error')
-        mock_Popen.return_value = podman
-        with raises(CgylePodmanError):
-            self.catalog.get_catalog_podman_search(
+        mock_extract_bearer_parameters.reset_mock()
+        mock_extract_bearer_parameters.return_value = ('realm', 'service')
+        mock_fetch.return_value = {
+            'token': None
+        }
+        with raises(CgyleCatalogError):
+            self.catalog.get_catalog(
                 'https://registry.opensuse.org'
             )
-
-    @patch('cgyle.proxy.subprocess.Popen')
-    def test_get_catalog_podman_search_raises(self, mock_Popen):
-        mock_Popen.side_effect = Exception
-        with raises(CgyleCommandError):
-            self.catalog.get_catalog_podman_search(
+        mock_get_auth_challenge.return_value = None
+        mock_fetch.return_value = {
+            'errors': 'some'
+        }
+        with raises(CgyleCatalogError):
+            self.catalog.get_catalog(
                 'https://registry.opensuse.org'
             )
-
-    @patch('time.sleep')
-    @patch('cgyle.proxy.subprocess.Popen')
-    def test_get_catalog_podman_search(self, mock_Popen, mock_time):
-        podman = Mock()
-        podman.communicate.return_value = (b'server/A\nserver/B', b'')
-        mock_Popen.return_value = podman
-        assert self.catalog.get_catalog_podman_search(
-            'https://registry.opensuse.org', True, 'user:pwd'
-        ) == ['A', 'B']
-        mock_Popen.assert_called_once_with(
-            [
-                'podman', 'search', '--tls-verify=true',
-                '--limit', '2147483647', '--creds', 'user:pwd',
-                'registry.opensuse.org:/'
-            ], stdout=-1, stderr=-1
-        )
 
     def test_apply_filter_raises(self):
         with raises(CgyleFilterExpressionError):

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -42,7 +42,6 @@ class TestCli:
         catalog.apply_filter.return_value = ['some-container']
         catalog.translate_policy.return_value = []
         mock_Catalog.return_value = catalog
-        self.cli.use_podman_search = False
         self.cli.dryrun = True
         self.cli.pattern = '.*'
         self.cli.policy = '../data/policy'
@@ -131,7 +130,6 @@ class TestCli:
             ('/var/log/cgyle/some/outside/catalog', [], ['some.log'])
         ]
         self.cli.dryrun = False
-        self.cli.use_podman_search = False
         self.cli.local_distribution_cache = None
 
         with patch('builtins.open', create=True) as mock_open:
@@ -161,21 +159,8 @@ class TestCli:
         catalog = Mock()
         catalog.get_catalog.return_value = ['some/container']
         mock_Catalog.return_value = catalog
-        self.cli.use_podman_search = False
         self.cli.dryrun = True
         self.cli._get_catalog()
         catalog.get_catalog.assert_called_once_with(
-            'registry.opensuse.org'
-        )
-
-    @patch('cgyle.cli.Catalog')
-    def test_get_catalog_podman_search(self, mock_Catalog):
-        catalog = Mock()
-        catalog.get_catalog_podman_search.return_value = ['some/container']
-        mock_Catalog.return_value = catalog
-        self.cli.use_podman_search = True
-        self.cli.dryrun = True
-        self.cli._get_catalog()
-        catalog.get_catalog_podman_search.assert_called_once_with(
-            'registry.opensuse.org', True, ''
+            'registry.opensuse.org', ''
         )

--- a/test/unit/response_test.py
+++ b/test/unit/response_test.py
@@ -1,12 +1,8 @@
-from unittest.mock import (
-    patch, Mock
-)
+import requests
+from unittest.mock import patch
 from pytest import raises
 from cgyle.response import Response
-from cgyle.exceptions import (
-    CgyleJsonError,
-    CgyleRequestError
-)
+from cgyle.exceptions import CgyleRequestError
 
 
 class TestResponse:
@@ -16,25 +12,44 @@ class TestResponse:
     def setup_method(self, cls):
         self.setup()
 
-    @patch('cgyle.response.requests')
-    def test_get(self, mock_requests):
-        response = Mock()
-        response.content = b'{"repositories": ["name"]}'
-        mock_requests.request.return_value = response
-        assert self.response.get(
-            'https://registry.opensuse.org/v2/_catalog'
-        ) == {'repositories': ['name']}
+    @patch.object(Response, 'fetch')
+    def test_get_auth_challenge(self, mock_fetch):
+        mock_fetch.return_value = {
+            'www-authenticate': 'Bearer realm="some"'
+        }
+        assert self.response.get_auth_challenge('some') == 'Bearer realm="some"'
 
-    @patch('cgyle.response.requests')
-    def test_get_raises_on_json_import(self, mock_requests):
-        response = Mock()
-        response.content = b'foo'
-        mock_requests.request.return_value = response
-        with raises(CgyleJsonError):
-            self.response.get('location')
+    def test_extract_bearer_parameters(self):
+        challenge = 'Bearer realm="some",service="some"'
+        assert self.response.extract_bearer_parameters(
+            challenge
+        ) == ('some', 'some')
 
-    @patch('cgyle.response.requests')
-    def test_get_raises_on_request(self, mock_requests):
-        mock_requests.request.side_effect = Exception
+    @patch('cgyle.response.requests.get')
+    def test_fetch(self, mock_requests_get):
+        mock_requests_get.return_value.content = '{"content": "value"}'
+        mock_requests_get.return_value.headers = {'header': 'some'}
+        self.response.fetch(
+            'some_url', user='user', password='pass'
+        )
+        mock_requests_get.assert_called_with(
+            'some_url', headers={}, auth=('user', 'pass'), timeout=300
+        )
+        assert self.response.fetch(
+            'some_url', parameters={'some': 'value'}
+        ) == {
+            'content': 'value',
+            'header': 'some'
+        }
+
+    @patch('cgyle.response.requests.get')
+    def test_fetch_raises_on_request_handling(self, mock_requests_get):
+        mock_requests_get.side_effect = Exception
         with raises(CgyleRequestError):
-            self.response.get('location')
+            self.response.fetch('some_url')
+
+    @patch('cgyle.response.requests.get')
+    def test_fetch_raises_on_timeout(self, mock_requests_get):
+        mock_requests_get.side_effect = requests.exceptions.Timeout
+        with raises(CgyleRequestError):
+            self.response.fetch('some_url')


### PR DESCRIPTION
Do not require podman for retrieving the catalog and implement a generic request based solution against the v2/_catalog API. This fixes potential entry limits from podman search