### PR TITLE
changing service to type oneshot and added ExecStartPost for GC

### DIFF
--- a/systemd/registry-suse-com.service
+++ b/systemd/registry-suse-com.service
@@ -2,7 +2,7 @@
 Description=Cache update for registry.suse.com
 
 [Service]
-Type=simple
+Type=oneshot
 User=_rmt
 Group=nginx
 RuntimeMaxSec=5h
@@ -10,3 +10,4 @@ Restart=on-failure
 ExecStartPre=/bin/bash -c "rm -rf /tmp/containers-user-$(id -u _rmt)"
 RestartSec=30s
 ExecStart=cgyle --max-requests 1 --updatecache local://distribution:/var/lib/rmt/public/repo/registry --proxy-creds /etc/rmt.conf --registry-creds /etc/rmt.conf --from https://registry.suse.com --filter-policy /etc/rmt/access_policies.yml --skip-policy-section free --arch x86_64 --arch aarch64 --arch arm64 --arch amd64 --apply
+ExecStartPost=+/bin/bash -c "sleep 10 && registry garbage-collect /etc/registry/config.yml -m"

--- a/systemd/registry-suse-com.service
+++ b/systemd/registry-suse-com.service
@@ -10,4 +10,4 @@ Restart=on-failure
 ExecStartPre=/bin/bash -c "rm -rf /tmp/containers-user-$(id -u _rmt)"
 RestartSec=30s
 ExecStart=cgyle --max-requests 1 --updatecache local://distribution:/var/lib/rmt/public/repo/registry --proxy-creds /etc/rmt.conf --registry-creds /etc/rmt.conf --from https://registry.suse.com --filter-policy /etc/rmt/access_policies.yml --skip-policy-section free --arch x86_64 --arch aarch64 --arch arm64 --arch amd64 --apply
-ExecStartPost=+/bin/bash -c "sleep 10 && registry garbage-collect /etc/registry/config.yml -m"
+ExecStartPost=/bin/bash -c "sleep 10 && registry garbage-collect /etc/registry/config.yml -m"


### PR DESCRIPTION
Run `registry garbage-collect` as ExecStartPost after cgyle completes, with a 10s delay to let the container shut down cleanly. Requires changing Type=simple to Type=oneshot so ExecStartPost waits for ExecStart to exit rather than firing immediately. GC runs with elevated privileges (+) since the service itself runs as User=_rmt but GC needs root.