### PR TITLE
Explicitly request policy sections

### DIFF
--- a/systemd/registry-suse-com.service
+++ b/systemd/registry-suse-com.service
@@ -9,5 +9,5 @@ RuntimeMaxSec=5h
 Restart=on-failure
 ExecStartPre=/bin/bash -c "rm -rf /tmp/containers-user-$(id -u _rmt)"
 RestartSec=30s
-ExecStart=cgyle --max-requests 1 --updatecache local://distribution:/var/lib/rmt/public/repo/registry --proxy-creds /etc/rmt.conf --registry-creds /etc/rmt.conf --from https://registry.suse.com --filter-policy /etc/rmt/access_policies.yml --skip-policy-section free --arch x86_64 --arch aarch64 --arch arm64 --arch amd64 --apply
 ExecStartPost=/bin/bash -c "sleep 10 && registry garbage-collect /etc/registry/config.yml -m"
+ExecStart=cgyle --max-requests 1 --updatecache local://distribution:/var/lib/rmt/public/repo/registry --proxy-creds /etc/rmt.conf --registry-creds /etc/rmt.conf --from https://registry.suse.com --filter-policy /etc/rmt/access_policies.yml --arch x86_64 --arch aarch64 --arch arm64 --arch amd64 --use-policy-section HPC15-SP5-LTSS-X86 --use-policy-section SLES12-SP5-LTSS-X86 --use-policy-section SLES15-SP3-LTSS-X86 --use-policy-section SLES15-SP4-LTSS-X86 --use-policy-section SLES15-SP5-LTSS-X86 --use-policy-section SLES15-SP6-LTSS-X86 --use-policy-section SMS-X86 --use-policy-section SMS-ARM64 --use-policy-section SM_ENT_MON_S --use-policy-section SM_ENT_MON_V --use-policy-section SMP --use-policy-section SMP-ARM64 --apply


### PR DESCRIPTION
Instead of skipping policy sections make sure to request only those we really want to sync containers from and expect the requesting user to have access permissions to this selection.